### PR TITLE
Optimize now playing bar stream

### DIFF
--- a/lib/widgets/now_playing_bar.dart
+++ b/lib/widgets/now_playing_bar.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:audio_service/audio_service.dart';
 import 'package:radiokapp/screens/audio_handler.dart' as local_audio;
 import 'package:radiokapp/screens/now_playing_screen.dart';
 
@@ -15,10 +14,11 @@ class NowPlayingBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<PlaybackState>(
-      stream: audioHandler.playbackState,
+    return StreamBuilder<bool>(
+      stream:
+          audioHandler.playbackState.map((s) => s.playing).distinct(),
       builder: (context, snapshot) {
-        final isPlaying = snapshot.data?.playing ?? false;
+        final isPlaying = snapshot.data ?? false;
 
         if (!isPlaying || currentStationName == null) {
           return const SizedBox(); // لا تظهر الشريط إذا لا يوجد بث


### PR DESCRIPTION
## Summary
- Map playback state stream to playing boolean and distinct to reduce rebuilds.

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e900763a4832fba90e8ba64f8f010