### PR TITLE
Use builder widgets for station lists and grids

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -297,9 +297,13 @@ class _MyAppState extends State<MyApp> {
   Widget _buildCurrentScreen() {
     if (_currentIndex == 1) {
       final favs = _stations.where((s) => s.isFavorite).toList();
-      return favs.isEmpty
-          ? const Center(child: Text('لا توجد محطات مفضلة بعد'))
-          : ListView(children: favs.map(_buildStationTile).toList());
+      if (favs.isEmpty) {
+        return const Center(child: Text('لا توجد محطات مفضلة بعد'));
+      }
+      return ListView.builder(
+        itemCount: favs.length,
+        itemBuilder: (context, index) => _buildStationTile(favs[index]),
+      );
     } else if (_currentIndex == 2) {
       return const Center(
         child: Padding(
@@ -312,7 +316,10 @@ class _MyAppState extends State<MyApp> {
         ),
       );
     } else {
-      return ListView(children: _stations.map(_buildStationTile).toList());
+      return ListView.builder(
+        itemCount: _stations.length,
+        itemBuilder: (context, index) => _buildStationTile(_stations[index]),
+      );
     }
   }
 

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -169,57 +169,59 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget _buildHomeScreen() {
     return Padding(
       padding: const EdgeInsets.all(16),
-      child: GridView.count(
-        crossAxisCount: 2,
-        crossAxisSpacing: 12,
-        mainAxisSpacing: 12,
-        childAspectRatio: 0.9,
-        children:
-            _stations.map((station) {
-              final isCurrent = _currentStationUrl == station.url;
-              return Card(
-                elevation: 2,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(12),
-                  onTap: () => _selectStation(station),
-                  child: Padding(
-                    padding: const EdgeInsets.all(12),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.radio,
-                          size: 40,
-                          color: isCurrent ? Colors.blue : Colors.grey,
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          station.name,
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        IconButton(
-                          icon: Icon(
-                            station.isFavorite
-                                ? Icons.favorite
-                                : Icons.favorite_border,
-                            color:
-                                station.isFavorite ? Colors.red : Colors.grey,
-                          ),
-                          onPressed: () => _toggleFavorite(station),
-                        ),
-                      ],
+      child: GridView.builder(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          crossAxisSpacing: 12,
+          mainAxisSpacing: 12,
+          childAspectRatio: 0.9,
+        ),
+        itemCount: _stations.length,
+        itemBuilder: (context, index) {
+          final station = _stations[index];
+          final isCurrent = _currentStationUrl == station.url;
+          return Card(
+            elevation: 2,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: InkWell(
+              borderRadius: BorderRadius.circular(12),
+              onTap: () => _selectStation(station),
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.radio,
+                      size: 40,
+                      color: isCurrent ? Colors.blue : Colors.grey,
                     ),
-                  ),
+                    const SizedBox(height: 8),
+                    Text(
+                      station.name,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    IconButton(
+                      icon: Icon(
+                        station.isFavorite
+                            ? Icons.favorite
+                            : Icons.favorite_border,
+                        color: station.isFavorite ? Colors.red : Colors.grey,
+                      ),
+                      onPressed: () => _toggleFavorite(station),
+                    ),
+                  ],
                 ),
-              );
-            }).toList(),
+              ),
+            ),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Use `ListView.builder` in `main.dart` to lazily build station tiles and favorites.
- Replace `GridView.count` with `GridView.builder` in home screen for on-demand tile creation.

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fec54379c832fb8ed242b5fda14e3