### PR TITLE
Use AnimationController for welcome screen icon scaling

### DIFF
--- a/lib/screens/welcome.dart
+++ b/lib/screens/welcome.dart
@@ -1,34 +1,45 @@
 import 'package:flutter/material.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        AnimationController(vsync: this, duration: const Duration(seconds: 1))
+          ..repeat(reverse: true);
+    _scaleAnimation = Tween<double>(begin: 0.8, end: 1.2)
+        .animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('الرئيسية')),
       body: Center(
-        child: TweenAnimationBuilder(
-          tween: Tween<double>(begin: 0.8, end: 1.2),
-          duration: const Duration(seconds: 1),
-          curve: Curves.easeInOut,
-          builder: (context, scale, child) {
-            return Transform.scale(
-              scale: scale,
-              child: const Icon(
-                Icons.storefront, // شعار المتجر
-                size: 100,
-                color: Colors.blue,
-              ),
-            );
-          },
-          onEnd: () {
-            // تعيد الحركة باستمرار
-            Future.delayed(
-              Duration.zero,
-              () => (context as Element).markNeedsBuild(),
-            );
-          },
+        child: ScaleTransition(
+          scale: _scaleAnimation,
+          child: const Icon(
+            Icons.storefront,
+            size: 100,
+            color: Colors.blue,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- refactor welcome screen to use an AnimationController that repeats the scaling animation
- wrap storefront icon in a ScaleTransition driven by the controller
- remove manual rebuild logic using `onEnd`

## Testing
- `dart format lib/screens/welcome.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fed65fe54832f8553665b8379ea91