### PR TITLE
Avoid stopping playback before switching stations

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -148,7 +148,6 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> _playStation(RadioStation station) async {
     try {
-      await _player.stop();
       await _player.setUrl(station.url);
       await _player.play();
       setState(() {

--- a/lib/screens/favorites.dart
+++ b/lib/screens/favorites.dart
@@ -23,7 +23,6 @@ class FavoritesScreen extends StatelessWidget {
     if (currentStationUrl == url) {
       await audioHandler.stop();
     } else {
-      await audioHandler.stop();
       await audioHandler.setUrl(url);
       await audioHandler.play();
     }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -90,7 +90,6 @@ class _HomeScreenState extends State<HomeScreen> {
         _currentStationUrl = null;
       });
     } else {
-      await widget.audioHandler.stop();
       await widget.audioHandler.setUrl(station.url);
       await widget.audioHandler.play();
       setState(() {


### PR DESCRIPTION
## Summary
- remove unnecessary stop before setting a new station in `_playStation`, `_selectStation`, and `_handleTap`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff2f06b30832fbf5f8ea37872b6c2