### PR TITLE
feat: add detailed error alert component and translations

### DIFF
--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -1,0 +1,9 @@
+{
+  "errorAlert": {
+    "title": "حدث خطأ",
+    "reason": "السبب: {{reason}}",
+    "suggestion": "الاقتراح: {{suggestion}}",
+    "showDetails": "عرض التفاصيل",
+    "hideDetails": "إخفاء التفاصيل"
+  }
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,9 @@
+{
+  "errorAlert": {
+    "title": "An error occurred",
+    "reason": "Reason: {{reason}}",
+    "suggestion": "Suggested fix: {{suggestion}}",
+    "showDetails": "Show details",
+    "hideDetails": "Hide details"
+  }
+}

--- a/src/components/ErrorAlert.tsx
+++ b/src/components/ErrorAlert.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import en from '../../i18n/en.json';
+
+type Translation = typeof en.errorAlert;
+
+interface ErrorAlertProps {
+  translation?: Translation;
+  reason: string;
+  suggestion: string;
+  technicalDetails?: string;
+}
+
+const ErrorAlert: React.FC<ErrorAlertProps> = ({
+  translation = en.errorAlert,
+  reason,
+  suggestion,
+  technicalDetails,
+}) => {
+  const [showDetails, setShowDetails] = useState(false);
+
+  const toggleDetails = () => setShowDetails((prev) => !prev);
+
+  return (
+    <div role="alert" className="error-alert">
+      <p>{translation.title}</p>
+      <p>{translation.reason.replace('{{reason}}', reason)}</p>
+      <p>{translation.suggestion.replace('{{suggestion}}', suggestion)}</p>
+      {technicalDetails && (
+        <div>
+          <button onClick={toggleDetails}>
+            {showDetails ? translation.hideDetails : translation.showDetails}
+          </button>
+          {showDetails && <pre>{technicalDetails}</pre>}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ErrorAlert;


### PR DESCRIPTION
## Summary
- add ErrorAlert component with optional detail toggle
- provide English and Arabic translations including error reason and suggestions

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688ff8833f10832fa54b790dd3538c1f