### PR TITLE
Add error banner styling and component

### DIFF
--- a/lib/error_banner.dart
+++ b/lib/error_banner.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class ErrorBanner extends StatefulWidget {
+  final String message;
+  const ErrorBanner({super.key, required this.message});
+
+  @override
+  State<ErrorBanner> createState() => _ErrorBannerState();
+}
+
+class _ErrorBannerState extends State<ErrorBanner>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _fade;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    )..forward();
+    _fade = CurvedAnimation(parent: _controller, curve: Curves.easeInOut);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _fade,
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: const Color(0xFFF8D7DA),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text(
+          widget.message,
+          style: const TextStyle(color: Color(0xFF721C24)),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'error_banner.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -263,10 +264,7 @@ class _MyAppState extends State<MyApp> {
               if (_errorMessage != null)
                 Padding(
                   padding: const EdgeInsets.all(8),
-                  child: Text(
-                    _errorMessage!,
-                    style: const TextStyle(color: Colors.red),
-                  ),
+                  child: ErrorBanner(message: _errorMessage!),
                 ),
               Expanded(child: _buildCurrentScreen()),
             ],

--- a/src/styles/error.css
+++ b/src/styles/error.css
@@ -1,0 +1,18 @@
+.error-banner {
+  background-color: #f8d7da;
+  color: #721c24;
+  padding: 12px;
+  border-radius: 4px;
+  animation: fade-in 0.3s ease-in-out;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,7 @@
 
   <title>radiokapp</title>
   <link rel="manifest" href="manifest.json">
+  <link rel="stylesheet" href="../src/styles/error.css">
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>


### PR DESCRIPTION
## Summary
- add error banner stylesheet with fade-in animation
- introduce `ErrorBanner` widget and apply it to error message display
- link the new stylesheet in the web entry HTML

## Testing
- `rg "error-message" src/styles/` (fails: No such file or directory)
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff9b4e520832fa8654ab55a6e3f93