### PR TITLE
feat: add error id tracking

### DIFF
--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/node';
+
+// توليد معرف فريد لكل خطأ
+export function generateErrorId(): string {
+  return Math.random().toString(36).substring(2, 10);
+}
+
+// إرسال الخطأ ومعرفه إلى خدمة التتبع
+export function logError(message: string, errorId: string, error?: unknown): void {
+  Sentry.captureException(error instanceof Error ? error : new Error(String(error)), {
+    tags: { errorId },
+    extra: { message },
+  });
+}
+
+// معالجة الأخطاء العامة وإرجاع رسالة للمستخدم تحتوي على المعرف
+export function handleError(error: unknown): { errorId: string; userMessage: string } {
+  const message = error instanceof Error ? error.message : String(error);
+  const errorId = generateErrorId();
+  logError(message, errorId, error);
+
+  const userMessage = `حدث خطأ غير متوقع. الرجاء مشاركة هذا المعرف مع فريق الدعم: ${errorId}`;
+  console.error(userMessage);
+  return { errorId, userMessage };
+}


### PR DESCRIPTION
## Summary
- generate unique error ids and log errors with Sentry
- return id in user-facing error messages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ffb366c4c832f80b8dc3e54d0aa1c