### PR TITLE
feat: extract station card widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'widgets/station_card.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -318,27 +319,15 @@ class _MyAppState extends State<MyApp> {
 
   Widget _buildStationTile(RadioStation station) {
     final isPlaying = _currentStationUrl == station.url;
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: ListTile(
-        leading: const Icon(Icons.radio),
-        title: Text(station.name),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            IconButton(
-              icon: Icon(
-                station.isFavorite ? Icons.favorite : Icons.favorite_border,
-                color: station.isFavorite ? Colors.red : null,
-              ),
-              onPressed: () => _toggleFavorite(station),
-            ),
-            IconButton(
-              icon: Icon(isPlaying ? Icons.stop : Icons.play_arrow),
-              onPressed: isPlaying ? _stopPlaying : () => _playStation(station),
-            ),
-          ],
-        ),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: StationCard(
+        name: station.name,
+        isPlaying: isPlaying,
+        isFavorite: station.isFavorite,
+        onTap:
+            isPlaying ? _stopPlaying : () => _playStation(station),
+        onToggleFavorite: () => _toggleFavorite(station),
       ),
     );
   }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:radiokapp/screens/audio_handler.dart';
 import 'package:radiokapp/widgets/now_playing_bar.dart';
+import 'package:radiokapp/widgets/station_card.dart';
 
 class RadioStation {
   final String name;
@@ -174,52 +175,16 @@ class _HomeScreenState extends State<HomeScreen> {
         crossAxisSpacing: 12,
         mainAxisSpacing: 12,
         childAspectRatio: 0.9,
-        children:
-            _stations.map((station) {
-              final isCurrent = _currentStationUrl == station.url;
-              return Card(
-                elevation: 2,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: InkWell(
-                  borderRadius: BorderRadius.circular(12),
-                  onTap: () => _selectStation(station),
-                  child: Padding(
-                    padding: const EdgeInsets.all(12),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.radio,
-                          size: 40,
-                          color: isCurrent ? Colors.blue : Colors.grey,
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          station.name,
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        IconButton(
-                          icon: Icon(
-                            station.isFavorite
-                                ? Icons.favorite
-                                : Icons.favorite_border,
-                            color:
-                                station.isFavorite ? Colors.red : Colors.grey,
-                          ),
-                          onPressed: () => _toggleFavorite(station),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              );
-            }).toList(),
+        children: _stations.map((station) {
+          final isCurrent = _currentStationUrl == station.url;
+          return StationCard(
+            name: station.name,
+            isPlaying: isCurrent,
+            isFavorite: station.isFavorite,
+            onTap: () => _selectStation(station),
+            onToggleFavorite: () => _toggleFavorite(station),
+          );
+        }).toList(),
       ),
     );
   }

--- a/lib/widgets/station_card.dart
+++ b/lib/widgets/station_card.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+class StationCard extends StatelessWidget {
+  final String name;
+  final bool isPlaying;
+  final bool isFavorite;
+  final VoidCallback onTap;
+  final VoidCallback onToggleFavorite;
+
+  const StationCard({
+    Key? key,
+    required this.name,
+    required this.isPlaying,
+    required this.isFavorite,
+    required this.onTap,
+    required this.onToggleFavorite,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 2,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.radio,
+                size: 40,
+                color: isPlaying ? Colors.blue : Colors.grey,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                name,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              IconButton(
+                icon: Icon(
+                  isFavorite ? Icons.favorite : Icons.favorite_border,
+                  color: isFavorite ? Colors.red : Colors.grey,
+                ),
+                onPressed: onToggleFavorite,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- create reusable `StationCard` widget with play and favorite controls
- use `StationCard` in home and main screens to show stations

## Testing
- `dart format lib/widgets/station_card.dart lib/screens/home.dart lib/main.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689007f62edc832fbf0268758d233849