### PR TITLE
feat: show playing icon for active stations

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -322,7 +322,22 @@ class _MyAppState extends State<MyApp> {
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: ListTile(
         leading: const Icon(Icons.radio),
-        title: Text(station.name),
+        title: Row(
+          children: [
+            AnimatedOpacity(
+              opacity: isPlaying ? 1.0 : 0.0,
+              duration: const Duration(milliseconds: 300),
+              child: const Icon(Icons.graphic_eq, size: 20),
+            ),
+            const SizedBox(width: 4),
+            Expanded(
+              child: Text(
+                station.name,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/screens/favorites.dart
+++ b/lib/screens/favorites.dart
@@ -51,9 +51,21 @@ class FavoritesScreen extends StatelessWidget {
                             Icons.radio,
                             color: isCurrent ? Colors.blue : Colors.grey,
                           ),
-                          title: Text(
-                            station['name'] ?? 'محطة غير معروفة',
-                            overflow: TextOverflow.ellipsis,
+                          title: Row(
+                            children: [
+                              AnimatedOpacity(
+                                opacity: isCurrent ? 1.0 : 0.0,
+                                duration: const Duration(milliseconds: 300),
+                                child: const Icon(Icons.graphic_eq, size: 20),
+                              ),
+                              const SizedBox(width: 4),
+                              Expanded(
+                                child: Text(
+                                  station['name'] ?? 'محطة غير معروفة',
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ],
                           ),
                           trailing: Row(
                             mainAxisSize: MainAxisSize.min,

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -196,12 +196,27 @@ class _HomeScreenState extends State<HomeScreen> {
                           color: isCurrent ? Colors.blue : Colors.grey,
                         ),
                         const SizedBox(height: 8),
-                        Text(
-                          station.name,
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
+                        SizedBox(
+                          width: double.infinity,
+                          child: Row(
+                            children: [
+                              AnimatedOpacity(
+                                opacity: isCurrent ? 1.0 : 0.0,
+                                duration: const Duration(milliseconds: 300),
+                                child: const Icon(Icons.graphic_eq, size: 20),
+                              ),
+                              const SizedBox(width: 4),
+                              Expanded(
+                                child: Text(
+                                  station.name,
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(
+                                    fontSize: 16,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                         IconButton(
@@ -240,7 +255,22 @@ class _HomeScreenState extends State<HomeScreen> {
             Icons.radio,
             color: isCurrent ? Colors.blue : Colors.grey,
           ),
-          title: Text(station.name),
+          title: Row(
+            children: [
+              AnimatedOpacity(
+                opacity: isCurrent ? 1.0 : 0.0,
+                duration: const Duration(milliseconds: 300),
+                child: const Icon(Icons.graphic_eq, size: 20),
+              ),
+              const SizedBox(width: 4),
+              Expanded(
+                child: Text(
+                  station.name,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
           trailing: IconButton(
             icon: const Icon(Icons.favorite, color: Colors.red),
             onPressed: () => _toggleFavorite(station),


### PR DESCRIPTION
## Summary
- show animated playing icon beside station names in station tiles
- apply the same playing indicator to home grid cards and favorites listings

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68900e0785b0832f9f603fd64723fafe