### PR TITLE
Add animated wave activity indicator for playing stations

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'widgets/animated_wave.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -322,7 +323,13 @@ class _MyAppState extends State<MyApp> {
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: ListTile(
         leading: const Icon(Icons.radio),
-        title: Text(station.name),
+        title: Row(
+          children: [
+            AnimatedWave(isActive: isPlaying),
+            const SizedBox(width: 4),
+            Expanded(child: Text(station.name)),
+          ],
+        ),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:radiokapp/screens/audio_handler.dart';
 import 'package:radiokapp/widgets/now_playing_bar.dart';
+import 'package:radiokapp/widgets/animated_wave.dart';
 
 class RadioStation {
   final String name;
@@ -196,13 +197,22 @@ class _HomeScreenState extends State<HomeScreen> {
                           color: isCurrent ? Colors.blue : Colors.grey,
                         ),
                         const SizedBox(height: 8),
-                        Text(
-                          station.name,
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            AnimatedWave(isActive: isCurrent),
+                            const SizedBox(width: 4),
+                            Flexible(
+                              child: Text(
+                                station.name,
+                                textAlign: TextAlign.center,
+                                style: const TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
                         IconButton(
                           icon: Icon(
@@ -240,7 +250,13 @@ class _HomeScreenState extends State<HomeScreen> {
             Icons.radio,
             color: isCurrent ? Colors.blue : Colors.grey,
           ),
-          title: Text(station.name),
+          title: Row(
+            children: [
+              AnimatedWave(isActive: isCurrent),
+              const SizedBox(width: 4),
+              Expanded(child: Text(station.name)),
+            ],
+          ),
           trailing: IconButton(
             icon: const Icon(Icons.favorite, color: Colors.red),
             onPressed: () => _toggleFavorite(station),

--- a/lib/widgets/animated_wave.dart
+++ b/lib/widgets/animated_wave.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+class AnimatedWave extends StatefulWidget {
+  final bool isActive;
+
+  const AnimatedWave({Key? key, required this.isActive}) : super(key: key);
+
+  @override
+  State<AnimatedWave> createState() => _AnimatedWaveState();
+}
+
+class _AnimatedWaveState extends State<AnimatedWave>
+    with TickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _anim1;
+  late final Animation<double> _anim2;
+  late final Animation<double> _anim3;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        AnimationController(vsync: this, duration: const Duration(milliseconds: 600));
+
+    _anim1 = Tween<double>(begin: 4, end: 12).animate(
+      CurvedAnimation(parent: _controller, curve: const Interval(0.0, 1.0)),
+    );
+    _anim2 = Tween<double>(begin: 4, end: 12).animate(
+      CurvedAnimation(parent: _controller, curve: const Interval(0.2, 1.0)),
+    );
+    _anim3 = Tween<double>(begin: 4, end: 12).animate(
+      CurvedAnimation(parent: _controller, curve: const Interval(0.4, 1.0)),
+    );
+
+    if (widget.isActive) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AnimatedWave oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isActive && !_controller.isAnimating) {
+      _controller.repeat(reverse: true);
+    } else if (!widget.isActive && _controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Widget _buildBar(Animation<double> animation) {
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, child) {
+        return Container(
+          width: 3,
+          height: animation.value,
+          color: Theme.of(context).colorScheme.primary,
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        _buildBar(_anim1),
+        const SizedBox(width: 2),
+        _buildBar(_anim2),
+        const SizedBox(width: 2),
+        _buildBar(_anim3),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add AnimatedWave widget with three animated bars using AnimationController.repeat
- show AnimatedWave before station names when playing across main list and favorites

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689013eb856c832fae54972f97213321