### PR TITLE
feat: animate station icons when playing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,9 +64,10 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
   late final AudioPlayer _player;
   late SharedPreferences _prefs;
+  late final AnimationController _iconController;
 
   List<RadioStation> _stations = [];
   bool _isDarkMode = false;
@@ -80,6 +81,8 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
     _player = AudioPlayer();
+    _iconController =
+        AnimationController(vsync: this, duration: const Duration(seconds: 1));
     _initApp();
   }
 
@@ -156,6 +159,7 @@ class _MyAppState extends State<MyApp> {
         _nowPlaying = station.name;
         _errorMessage = null;
       });
+      _iconController.repeat();
     } catch (e) {
       setState(() {
         _errorMessage = 'فشل تشغيل المحطة: $e';
@@ -171,6 +175,8 @@ class _MyAppState extends State<MyApp> {
       _currentStationUrl = null;
       _nowPlaying = null;
     });
+    _iconController.stop();
+    _iconController.reset();
   }
 
   void _toggleFavorite(RadioStation station) {
@@ -197,6 +203,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void dispose() {
     _player.dispose();
+    _iconController.dispose();
     super.dispose();
   }
 
@@ -321,7 +328,10 @@ class _MyAppState extends State<MyApp> {
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: ListTile(
-        leading: const Icon(Icons.radio),
+        leading: RotationTransition(
+          turns: isPlaying ? _iconController : const AlwaysStoppedAnimation(0),
+          child: const Icon(Icons.radio),
+        ),
         title: Text(station.name),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -31,16 +31,20 @@ class HomeScreen extends StatefulWidget {
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen> {
+class _HomeScreenState extends State<HomeScreen>
+    with SingleTickerProviderStateMixin {
   List<RadioStation> _stations = [];
   late SharedPreferences _prefs;
   bool _isReady = false;
   int _currentIndex = 0;
   String? _currentStationUrl;
+  late final AnimationController _iconController;
 
   @override
   void initState() {
     super.initState();
+    _iconController =
+        AnimationController(vsync: this, duration: const Duration(seconds: 1));
     _initPrefsAndLoadStations();
   }
 
@@ -89,6 +93,8 @@ class _HomeScreenState extends State<HomeScreen> {
       setState(() {
         _currentStationUrl = null;
       });
+      _iconController.stop();
+      _iconController.reset();
     } else {
       await widget.audioHandler.stop();
       await widget.audioHandler.setUrl(station.url);
@@ -96,7 +102,14 @@ class _HomeScreenState extends State<HomeScreen> {
       setState(() {
         _currentStationUrl = station.url;
       });
+      _iconController.repeat();
     }
+  }
+
+  @override
+  void dispose() {
+    _iconController.dispose();
+    super.dispose();
   }
 
   @override
@@ -190,10 +203,15 @@ class _HomeScreenState extends State<HomeScreen> {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(
-                          Icons.radio,
-                          size: 40,
-                          color: isCurrent ? Colors.blue : Colors.grey,
+                        RotationTransition(
+                          turns: isCurrent
+                              ? _iconController
+                              : const AlwaysStoppedAnimation(0),
+                          child: Icon(
+                            Icons.radio,
+                            size: 40,
+                            color: isCurrent ? Colors.blue : Colors.grey,
+                          ),
                         ),
                         const SizedBox(height: 8),
                         Text(
@@ -236,9 +254,14 @@ class _HomeScreenState extends State<HomeScreen> {
         final station = favorites[index];
         final isCurrent = _currentStationUrl == station.url;
         return ListTile(
-          leading: Icon(
-            Icons.radio,
-            color: isCurrent ? Colors.blue : Colors.grey,
+          leading: RotationTransition(
+            turns: isCurrent
+                ? _iconController
+                : const AlwaysStoppedAnimation(0),
+            child: Icon(
+              Icons.radio,
+              color: isCurrent ? Colors.blue : Colors.grey,
+            ),
           ),
           title: Text(station.name),
           trailing: IconButton(


### PR DESCRIPTION
## Summary
- add rotating radio icons driven by AnimationController
- start/stop animation when stations play or stop in both main and home screens

## Testing
- `dart format lib/main.dart lib/screens/home.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68901aa55238832fa4b064a342d1a03d