### PR TITLE
Enable swipe deletion for favorite stations

### DIFF
--- a/lib/screens/favorites.dart
+++ b/lib/screens/favorites.dart
@@ -46,34 +46,64 @@ class FavoritesScreen extends StatelessWidget {
                         final url = station['url'];
                         final isCurrent = currentStationUrl == url;
 
-                        return ListTile(
-                          leading: Icon(
-                            Icons.radio,
-                            color: isCurrent ? Colors.blue : Colors.grey,
+                        final dismissibleBackground = Container(
+                          color: Colors.red,
+                          alignment: Alignment.centerRight,
+                          padding: const EdgeInsets.symmetric(horizontal: 20),
+                          child: const Icon(Icons.delete, color: Colors.white),
+                        );
+
+                        return Dismissible(
+                          key: Key(station['url'] ?? station['name'] ?? ''),
+                          background: Container(
+                            color: Colors.red,
+                            alignment: Alignment.centerLeft,
+                            padding:
+                                const EdgeInsets.symmetric(horizontal: 20),
+                            child:
+                                const Icon(Icons.delete, color: Colors.white),
                           ),
-                          title: Text(
-                            station['name'] ?? 'محطة غير معروفة',
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                          trailing: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              IconButton(
-                                icon: Icon(
-                                  isCurrent ? Icons.stop : Icons.play_arrow,
+                          secondaryBackground: dismissibleBackground,
+                          onDismissed: (_) async {
+                            if (currentStationUrl == url) {
+                              await audioHandler.stop();
+                            }
+                            onRemove(station);
+                          },
+                          child: ListTile(
+                            leading: Icon(
+                              Icons.radio,
+                              color: isCurrent ? Colors.blue : Colors.grey,
+                            ),
+                            title: Text(
+                              station['name'] ?? 'محطة غير معروفة',
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            trailing: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                IconButton(
+                                  icon: Icon(
+                                    isCurrent ? Icons.stop : Icons.play_arrow,
+                                  ),
+                                  onPressed: () => _handleTap(station),
                                 ),
-                                onPressed: () => _handleTap(station),
-                              ),
-                              IconButton(
-                                icon: const Icon(
-                                  Icons.favorite,
-                                  color: Colors.red,
+                                IconButton(
+                                  icon: const Icon(
+                                    Icons.favorite,
+                                    color: Colors.red,
+                                  ),
+                                  onPressed: () async {
+                                    if (currentStationUrl == url) {
+                                      await audioHandler.stop();
+                                    }
+                                    onRemove(station);
+                                  },
                                 ),
-                                onPressed: () => onRemove(station),
-                              ),
-                            ],
+                              ],
+                            ),
+                            onTap: () => _handleTap(station),
                           ),
-                          onTap: () => _handleTap(station),
                         );
                       },
                     ),

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -235,17 +235,50 @@ class _HomeScreenState extends State<HomeScreen> {
       itemBuilder: (context, index) {
         final station = favorites[index];
         final isCurrent = _currentStationUrl == station.url;
-        return ListTile(
-          leading: Icon(
-            Icons.radio,
-            color: isCurrent ? Colors.blue : Colors.grey,
+        return Dismissible(
+          key: Key(station.url),
+          background: Container(
+            color: Colors.red,
+            alignment: Alignment.centerLeft,
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: const Icon(Icons.delete, color: Colors.white),
           ),
-          title: Text(station.name),
-          trailing: IconButton(
-            icon: const Icon(Icons.favorite, color: Colors.red),
-            onPressed: () => _toggleFavorite(station),
+          secondaryBackground: Container(
+            color: Colors.red,
+            alignment: Alignment.centerRight,
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: const Icon(Icons.delete, color: Colors.white),
           ),
-          onTap: () => _selectStation(station),
+          onDismissed: (_) async {
+            if (_currentStationUrl == station.url) {
+              await widget.audioHandler.stop();
+              setState(() {
+                _currentStationUrl = null;
+              });
+            }
+            _toggleFavorite(station);
+            _saveFavorites();
+          },
+          child: ListTile(
+            leading: Icon(
+              Icons.radio,
+              color: isCurrent ? Colors.blue : Colors.grey,
+            ),
+            title: Text(station.name),
+            trailing: IconButton(
+              icon: const Icon(Icons.favorite, color: Colors.red),
+              onPressed: () async {
+                if (_currentStationUrl == station.url) {
+                  await widget.audioHandler.stop();
+                  setState(() {
+                    _currentStationUrl = null;
+                  });
+                }
+                _toggleFavorite(station);
+              },
+            ),
+            onTap: () => _selectStation(station),
+          ),
         );
       },
     );


### PR DESCRIPTION
## Summary
- Allow removing favorite stations by swiping in FavoritesScreen and HomeScreen
- Stop playback and update NowPlayingBar when current station is removed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68901f470128832f8fa42078d002fcbd