### PR TITLE
Enable swipe to delete favorites

### DIFF
--- a/lib/screens/favorites.dart
+++ b/lib/screens/favorites.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:radiokapp/screens/audio_handler.dart';
 import 'package:radiokapp/widgets/now_playing_bar.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-class FavoritesScreen extends StatelessWidget {
+class FavoritesScreen extends StatefulWidget {
   final List<Map<String, String>> favoriteStations;
   final Function(Map<String, String>) onRemove;
   final AudioHandler audioHandler;
@@ -16,17 +17,44 @@ class FavoritesScreen extends StatelessWidget {
     required this.currentStationUrl,
   });
 
+  @override
+  State<FavoritesScreen> createState() => _FavoritesScreenState();
+}
+
+class _FavoritesScreenState extends State<FavoritesScreen> {
+  late List<Map<String, String>> _favoriteStations;
+
+  @override
+  void initState() {
+    super.initState();
+    _favoriteStations = List<Map<String, String>>.from(widget.favoriteStations);
+  }
+
   void _handleTap(Map<String, String> station) async {
     final url = station['url'];
     if (url == null) return;
 
-    if (currentStationUrl == url) {
-      await audioHandler.stop();
+    if (widget.currentStationUrl == url) {
+      await widget.audioHandler.stop();
     } else {
-      await audioHandler.stop();
-      await audioHandler.setUrl(url);
-      await audioHandler.play();
+      await widget.audioHandler.stop();
+      await widget.audioHandler.setUrl(url);
+      await widget.audioHandler.play();
     }
+  }
+
+  Future<void> _removeStation(Map<String, String> station) async {
+    setState(() {
+      _favoriteStations
+          .removeWhere((s) => s['url'] == station['url']);
+    });
+    widget.onRemove(station);
+    final prefs = await SharedPreferences.getInstance();
+    final favoriteNames = _favoriteStations
+        .map((s) => s['name'] ?? '')
+        .where((name) => name.isNotEmpty)
+        .toList();
+    await prefs.setStringList('favorites', favoriteNames);
   }
 
   @override
@@ -36,17 +64,33 @@ class FavoritesScreen extends StatelessWidget {
       body: Column(
         children: [
           Expanded(
-            child:
-                favoriteStations.isEmpty
-                    ? const Center(child: Text('لا يوجد محطات مفضلة بعد'))
-                    : ListView.builder(
-                      itemCount: favoriteStations.length,
-                      itemBuilder: (context, index) {
-                        final station = favoriteStations[index];
-                        final url = station['url'];
-                        final isCurrent = currentStationUrl == url;
+            child: _favoriteStations.isEmpty
+                ? const Center(child: Text('لا يوجد محطات مفضلة بعد'))
+                : ListView.builder(
+                    itemCount: _favoriteStations.length,
+                    itemBuilder: (context, index) {
+                      final station = _favoriteStations[index];
+                      final url = station['url'];
+                      final isCurrent = widget.currentStationUrl == url;
 
-                        return ListTile(
+                      return Dismissible(
+                        key: ValueKey(station['url']),
+                        background: Container(
+                          color: Colors.red,
+                          alignment: Alignment.centerLeft,
+                          padding: const EdgeInsets.only(left: 20),
+                          child:
+                              const Icon(Icons.delete, color: Colors.white),
+                        ),
+                        secondaryBackground: Container(
+                          color: Colors.red,
+                          alignment: Alignment.centerRight,
+                          padding: const EdgeInsets.only(right: 20),
+                          child:
+                              const Icon(Icons.delete, color: Colors.white),
+                        ),
+                        onDismissed: (direction) => _removeStation(station),
+                        child: ListTile(
                           leading: Icon(
                             Icons.radio,
                             color: isCurrent ? Colors.blue : Colors.grey,
@@ -69,22 +113,23 @@ class FavoritesScreen extends StatelessWidget {
                                   Icons.favorite,
                                   color: Colors.red,
                                 ),
-                                onPressed: () => onRemove(station),
+                                onPressed: () => _removeStation(station),
                               ),
                             ],
                           ),
                           onTap: () => _handleTap(station),
-                        );
-                      },
-                    ),
+                        ),
+                      );
+                    },
+                  ),
           ),
           NowPlayingBar(
-            audioHandler: audioHandler,
-            currentStationName:
-                favoriteStations.firstWhere(
-                  (s) => s['url'] == currentStationUrl,
-                  orElse: () => {'name': ''},
-                )['name'] ??
+            audioHandler: widget.audioHandler,
+            currentStationName: _favoriteStations
+                    .firstWhere(
+                      (s) => s['url'] == widget.currentStationUrl,
+                      orElse: () => {'name': ''},
+                    )['name'] ??
                 '',
           ),
         ],

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -235,17 +235,33 @@ class _HomeScreenState extends State<HomeScreen> {
       itemBuilder: (context, index) {
         final station = favorites[index];
         final isCurrent = _currentStationUrl == station.url;
-        return ListTile(
-          leading: Icon(
-            Icons.radio,
-            color: isCurrent ? Colors.blue : Colors.grey,
+        return Dismissible(
+          key: ValueKey(station.url),
+          background: Container(
+            color: Colors.red,
+            alignment: Alignment.centerLeft,
+            padding: const EdgeInsets.only(left: 20),
+            child: const Icon(Icons.delete, color: Colors.white),
           ),
-          title: Text(station.name),
-          trailing: IconButton(
-            icon: const Icon(Icons.favorite, color: Colors.red),
-            onPressed: () => _toggleFavorite(station),
+          secondaryBackground: Container(
+            color: Colors.red,
+            alignment: Alignment.centerRight,
+            padding: const EdgeInsets.only(right: 20),
+            child: const Icon(Icons.delete, color: Colors.white),
           ),
-          onTap: () => _selectStation(station),
+          onDismissed: (direction) => _toggleFavorite(station),
+          child: ListTile(
+            leading: Icon(
+              Icons.radio,
+              color: isCurrent ? Colors.blue : Colors.grey,
+            ),
+            title: Text(station.name),
+            trailing: IconButton(
+              icon: const Icon(Icons.favorite, color: Colors.red),
+              onPressed: () => _toggleFavorite(station),
+            ),
+            onTap: () => _selectStation(station),
+          ),
         );
       },
     );


### PR DESCRIPTION
## Summary
- Allow removing favorite stations by swiping them away in both favorites screens
- Persist deletions to `SharedPreferences` for future sessions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689023d7d04c832fb47424da11ee10ab