### PR TITLE
feat: add animated wave indicator

### DIFF
--- a/lib/widgets/animated_wave.dart
+++ b/lib/widgets/animated_wave.dart
@@ -1,0 +1,97 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// A reusable widget that paints an animated sine wave.
+///
+/// [color] controls the color of the wave stroke and [height] determines
+/// the vertical size of the widget.
+class AnimatedWave extends StatefulWidget {
+  final Color color;
+  final double height;
+
+  const AnimatedWave({
+    Key? key,
+    this.color = Colors.blue,
+    this.height = 20,
+  }) : super(key: key);
+
+  @override
+  State<AnimatedWave> createState() => _AnimatedWaveState();
+}
+
+class _AnimatedWaveState extends State<AnimatedWave>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller =
+        AnimationController(vsync: this, duration: const Duration(seconds: 2))
+          ..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: widget.height,
+      width: double.infinity,
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (context, _) {
+          return CustomPaint(
+            painter: _WavePainter(
+              animationValue: _controller.value,
+              color: widget.color,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _WavePainter extends CustomPainter {
+  final double animationValue;
+  final Color color;
+
+  _WavePainter({required this.animationValue, required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+
+    final path = Path();
+    final midY = size.height / 2;
+    final amplitude = size.height / 2;
+
+    for (double x = 0; x <= size.width; x++) {
+      final y = midY + amplitude *
+          math.sin(2 * math.pi * (x / size.width + animationValue));
+      if (x == 0) {
+        path.moveTo(x, y);
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(_WavePainter oldDelegate) {
+    return oldDelegate.animationValue != animationValue ||
+        oldDelegate.color != color;
+  }
+}
+

--- a/lib/widgets/now_playing_bar.dart
+++ b/lib/widgets/now_playing_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:audio_service/audio_service.dart';
 import 'package:radiokapp/screens/audio_handler.dart' as local_audio;
 import 'package:radiokapp/screens/now_playing_screen.dart';
+import 'package:radiokapp/widgets/animated_wave.dart';
 
 class NowPlayingBar extends StatelessWidget {
   final local_audio.AudioHandler audioHandler;
@@ -49,8 +50,15 @@ class NowPlayingBar extends StatelessWidget {
               ],
             ),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
+                SizedBox(
+                  width: 40,
+                  child: AnimatedWave(
+                    color: Colors.white,
+                    height: 20,
+                  ),
+                ),
+                const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     'يتم الآن تشغيل: $currentStationName',


### PR DESCRIPTION
## Summary
- add reusable `AnimatedWave` widget with animation and custom painter
- show small animated wave in `NowPlayingBar` to visualize playback state

## Testing
- `dart format lib/widgets/animated_wave.dart lib/widgets/now_playing_bar.dart` (fails: command not found)
- `flutter format lib/widgets/animated_wave.dart lib/widgets/now_playing_bar.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689024ea500c832fa206bf68acb3aa86