### PR TITLE
Add animated now-playing indicator to station tiles

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -326,6 +326,12 @@ class _MyAppState extends State<MyApp> {
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
+            AnimatedSwitcher(
+              duration: const Duration(milliseconds: 300),
+              child: isPlaying
+                  ? const Icon(Icons.equalizer, key: ValueKey('playing'))
+                  : const SizedBox.shrink(key: ValueKey('stopped')),
+            ),
             IconButton(
               icon: Icon(
                 station.isFavorite ? Icons.favorite : Icons.favorite_border,

--- a/lib/screens/favorites.dart
+++ b/lib/screens/favorites.dart
@@ -58,6 +58,14 @@ class FavoritesScreen extends StatelessWidget {
                           trailing: Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
+                              AnimatedSwitcher(
+                                duration: const Duration(milliseconds: 300),
+                                child: isCurrent
+                                    ? const Icon(Icons.equalizer,
+                                        key: ValueKey('playing'))
+                                    : const SizedBox.shrink(
+                                        key: ValueKey('stopped')),
+                              ),
                               IconButton(
                                 icon: Icon(
                                   isCurrent ? Icons.stop : Icons.play_arrow,

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -204,6 +204,15 @@ class _HomeScreenState extends State<HomeScreen> {
                             fontWeight: FontWeight.bold,
                           ),
                         ),
+                        AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 300),
+                          child: isCurrent
+                              ? const Icon(Icons.equalizer,
+                                  key: ValueKey('playing'))
+                              : const SizedBox.shrink(
+                                  key: ValueKey('stopped')),
+                        ),
+                        const SizedBox(height: 8),
                         IconButton(
                           icon: Icon(
                             station.isFavorite
@@ -241,9 +250,20 @@ class _HomeScreenState extends State<HomeScreen> {
             color: isCurrent ? Colors.blue : Colors.grey,
           ),
           title: Text(station.name),
-          trailing: IconButton(
-            icon: const Icon(Icons.favorite, color: Colors.red),
-            onPressed: () => _toggleFavorite(station),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 300),
+                child: isCurrent
+                    ? const Icon(Icons.equalizer, key: ValueKey('playing'))
+                    : const SizedBox.shrink(key: ValueKey('stopped')),
+              ),
+              IconButton(
+                icon: const Icon(Icons.favorite, color: Colors.red),
+                onPressed: () => _toggleFavorite(station),
+              ),
+            ],
           ),
           onTap: () => _selectStation(station),
         );


### PR DESCRIPTION
## Summary
- show equalizer icon for current playing station
- animate indicator appearance using AnimatedSwitcher across station lists

## Testing
- `dart format lib/main.dart lib/screens/home.dart lib/screens/favorites.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689025e4f530832f9651c21043506b07