### PR TITLE
refactor: extract RadioStation model

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:radiokapp/models/radio_station.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -344,14 +345,4 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
-class RadioStation {
-  final String name;
-  final String url;
-  bool isFavorite;
-
-  RadioStation({
-    required this.name,
-    required this.url,
-    this.isFavorite = false,
-  });
 }

--- a/lib/models/radio_station.dart
+++ b/lib/models/radio_station.dart
@@ -1,0 +1,11 @@
+class RadioStation {
+  final String name;
+  final String url;
+  bool isFavorite;
+
+  RadioStation({
+    required this.name,
+    required this.url,
+    this.isFavorite = false,
+  });
+}

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -2,18 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:radiokapp/screens/audio_handler.dart';
 import 'package:radiokapp/widgets/now_playing_bar.dart';
-
-class RadioStation {
-  final String name;
-  final String url;
-  bool isFavorite;
-
-  RadioStation({
-    required this.name,
-    required this.url,
-    this.isFavorite = false,
-  });
-}
+import 'package:radiokapp/models/radio_station.dart';
 
 class HomeScreen extends StatefulWidget {
   final bool isDarkMode;


### PR DESCRIPTION
## Summary
- move `RadioStation` model to its own file
- remove duplicate class definitions

## Testing
- `dart format lib/models/radio_station.dart lib/main.dart lib/screens/home.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68902a43179c832fabe3ce511454fc7d