### PR TITLE
Add hero transition and animated station selection

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:radiokapp/screens/audio_handler.dart';
 import 'package:radiokapp/widgets/now_playing_bar.dart';
+import 'package:radiokapp/screens/now_playing_screen.dart';
 
 class RadioStation {
   final String name;
@@ -174,17 +175,43 @@ class _HomeScreenState extends State<HomeScreen> {
         crossAxisSpacing: 12,
         mainAxisSpacing: 12,
         childAspectRatio: 0.9,
-        children:
-            _stations.map((station) {
-              final isCurrent = _currentStationUrl == station.url;
-              return Card(
-                elevation: 2,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
+        children: _stations.map((station) {
+          final isCurrent = _currentStationUrl == station.url;
+          return Hero(
+            tag: station.name,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 300),
+              transform: Matrix4.identity()
+                ..scale(isCurrent ? 1.05 : 1.0),
+              decoration: BoxDecoration(
+                color: isCurrent ? Colors.blue.shade50 : Colors.white,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: const [
+                  BoxShadow(
+                    color: Colors.black12,
+                    blurRadius: 4,
+                    offset: Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: Material(
+                color: Colors.transparent,
                 child: InkWell(
                   borderRadius: BorderRadius.circular(12),
-                  onTap: () => _selectStation(station),
+                  onTap: () async {
+                    await _selectStation(station);
+                    if (mounted) {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => NowPlayingScreen(
+                            audioHandler: widget.audioHandler,
+                            stationName: station.name,
+                          ),
+                        ),
+                      );
+                    }
+                  },
                   child: Padding(
                     padding: const EdgeInsets.all(12),
                     child: Column(
@@ -218,8 +245,10 @@ class _HomeScreenState extends State<HomeScreen> {
                     ),
                   ),
                 ),
-              );
-            }).toList(),
+              ),
+            ),
+          );
+        }).toList(),
       ),
     );
   }

--- a/lib/screens/now_playing_screen.dart
+++ b/lib/screens/now_playing_screen.dart
@@ -40,7 +40,14 @@ class _NowPlayingScreenState extends State<NowPlayingScreen> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.radio, size: 100, color: Colors.blue.shade700),
+            Hero(
+              tag: widget.stationName ?? '',
+              child: Icon(
+                Icons.radio,
+                size: 100,
+                color: Colors.blue.shade700,
+              ),
+            ),
             const SizedBox(height: 30),
             Text(
               widget.stationName ?? 'لا يوجد محطة حالياً',


### PR DESCRIPTION
## Summary
- animate station cards on selection and navigate to NowPlayingScreen with a hero transition
- add matching hero widget in NowPlayingScreen for seamless animation

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68902d7e00fc832f8f6dac3ca44e88f3