### PR TITLE
refactor: use AnimationController on welcome screen

### DIFF
--- a/lib/screens/welcome.dart
+++ b/lib/screens/welcome.dart
@@ -1,32 +1,50 @@
 import 'package:flutter/material.dart';
 
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+class WelcomeScreen extends StatefulWidget {
+  const WelcomeScreen({super.key});
+
+  @override
+  State<WelcomeScreen> createState() => _WelcomeScreenState();
+}
+
+class _WelcomeScreenState extends State<WelcomeScreen>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(seconds: 1),
+      vsync: this,
+    )..repeat(reverse: true);
+    _animation = Tween<double>(begin: 0.8, end: 1.2).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('الرئيسية')),
       body: Center(
-        child: TweenAnimationBuilder(
-          tween: Tween<double>(begin: 0.8, end: 1.2),
-          duration: const Duration(seconds: 1),
-          curve: Curves.easeInOut,
-          builder: (context, scale, child) {
+        child: AnimatedBuilder(
+          animation: _animation,
+          builder: (context, child) {
             return Transform.scale(
-              scale: scale,
+              scale: _animation.value,
               child: const Icon(
-                Icons.storefront, // شعار المتجر
+                Icons.storefront,
                 size: 100,
                 color: Colors.blue,
               ),
-            );
-          },
-          onEnd: () {
-            // تعيد الحركة باستمرار
-            Future.delayed(
-              Duration.zero,
-              () => (context as Element).markNeedsBuild(),
             );
           },
         ),
@@ -34,3 +52,4 @@ class HomeScreen extends StatelessWidget {
     );
   }
 }
+


### PR DESCRIPTION
## Summary
- rename HomeScreen to WelcomeScreen
- use AnimationController.repeat for continuous icon scaling

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68903157968c832f85e5c847efad391a