### PR TITLE
Dispose audio player when service stops

### DIFF
--- a/lib/screens/audio_handler.dart
+++ b/lib/screens/audio_handler.dart
@@ -4,6 +4,7 @@ import 'package:audio_session/audio_session.dart';
 
 class AudioHandler extends BaseAudioHandler with SeekHandler {
   final AudioPlayer _player = AudioPlayer();
+  bool _isDisposed = false;
 
   AudioHandler() {
     _init();
@@ -76,6 +77,7 @@ class AudioHandler extends BaseAudioHandler with SeekHandler {
   Future<void> stop() async {
     await _player.stop();
     mediaItem.add(null);
+    await dispose();
   }
 
   Future<void> setUrl(String url) async {
@@ -101,5 +103,11 @@ class AudioHandler extends BaseAudioHandler with SeekHandler {
     } catch (e) {
       print('تعذر ضبط مستوى الصوت: $e');
     }
+  }
+
+  Future<void> dispose() async {
+    if (_isDisposed) return;
+    _isDisposed = true;
+    await _player.dispose();
   }
 }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -100,6 +100,12 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   @override
+  void dispose() {
+    widget.audioHandler.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     if (!_isReady) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));


### PR DESCRIPTION
## Summary
- add an idempotent `dispose` method in `AudioHandler`
- stop the audio service and dispose of the player when stopping
- ensure `HomeScreen` disposes of `AudioHandler`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68903277d2cc832f99a7c1aac151b019