### PR TITLE
Enable foreground audio playback

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.radiokapp">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
     <application
         android:label="radiokapp"
         android:name="${applicationName}"
@@ -35,6 +38,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <service
+            android:name="com.ryanheise.audioservice.AudioService"
+            android:exported="false" />
     </application>
 
     <!-- Required to query activities that can process text -->

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:just_audio_background/just_audio_background.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await JustAudioBackground.init();
   runApp(const MyAppEntry());
 }
 

--- a/lib/screens/radio_player.dart
+++ b/lib/screens/radio_player.dart
@@ -35,18 +35,17 @@ class RadioController {
       }
 
       await _player.setVolume(_volume);
-      await _player.setUrl(url);
-      await _player.play();
-
-      // تحديث إشعار الخلفية
-      AudioServiceBackground.setMediaItem(
-        MediaItem(
+      final source = AudioSource.uri(
+        Uri.parse(url),
+        tag: MediaItem(
           id: url,
           title: 'إذاعة مباشرة',
           artist: 'Radio K',
           artUri: Uri.parse('https://via.placeholder.com/150'),
         ),
       );
+      await _player.setAudioSource(source);
+      await _player.play();
 
       currentStationUrl = url;
     } catch (e) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   audio_session: ^0.2.2
   shared_preferences: ^2.2.2
   audio_service: ^0.18.18
+  just_audio_background: ^0.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add foreground service & wake lock permissions
- register AudioService and initialize background audio
- play streams with MediaItem metadata for notifications

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891e8389118832f84388a7857b97aba